### PR TITLE
Added "transition_animation=" method to Drawer

### DIFF
--- a/lib/ProMotion/menu/drawer.rb
+++ b/lib/ProMotion/menu/drawer.rb
@@ -4,6 +4,7 @@ module ProMotion
       include ::ProMotion::ScreenModule
       include Gestures
       include Visibility
+      include Transition
 
       def self.new(center=nil, options={})
         menu = alloc.init

--- a/lib/ProMotion/menu/transition.rb
+++ b/lib/ProMotion/menu/transition.rb
@@ -1,0 +1,45 @@
+module ProMotion; module Menu
+  module Transition
+
+     VISUAL_STATES = {
+      slide_and_scale:
+        {
+          block: MMDrawerVisualState.slideAndScaleVisualStateBlock,
+          # "Creates a slide and scale visual state block that gives an experience similar to Mailbox.app. It scales from 90% to 100%, and translates 50 pixels in the x direction. In addition, it also sets alpha from 0.0 to 1.0."
+        },
+      slide:
+        {
+          block: MMDrawerVisualState.slideVisualStateBlock,
+          # "Creates a slide visual state block that gives the user an experience that slides at the same speed of the center view controller during animation. This is equal to calling parallaxVisualStateBlockWithParallaxFactor: with a parallax factor of 1.0."
+        },
+      parallax:
+        {
+          block: MMDrawerVisualState.parallaxVisualStateBlockWithParallaxFactor(3),
+          # "Creates a parallax experience that slides the side drawer view controller at a different rate than the center view controller during animation. For every parallaxFactor of points moved by the center view controller, the side drawer view controller will move 1 point. Passing in 1.0 is the equivalent of a applying a sliding animation, while passing in 'MAX_FLOAT' is the equivalent of having no animation at all."
+        },
+      swinging_door:
+        {
+          block: MMDrawerVisualState.swingingDoorVisualStateBlock,
+          # "Creates a swinging door visual state block that gives the user an experience that animates the drawer in along the hinge."
+        }
+    }
+
+    def transition_animation=(visualBlock)
+      # Parallax requires a parallaxFactor. Set it by passing the visualBlock block in with underscore parallaxFactor attached to the end. i.e. transition_animation = :parallax_6 for parallaxFactor 6.
+
+      self.setDrawerVisualStateBlock(mask_for_transition(visualBlock))
+    end
+
+    def mask_for_transition(visualBlock)
+      unless visualBlock.nil?
+        if visualBlock.include? "parallax"
+          parallax_factor = visualBlock.include?("_") ? visualBlock.split("_")[1].to_i : 3
+          visual_state = MMDrawerVisualState.parallaxVisualStateBlockWithParallaxFactor(parallax_factor)
+        end
+      end
+      visual_state ||= VISUAL_STATES.keys.include?(visualBlock) ? VISUAL_STATES[visualBlock][:block] : nil
+      visual_state
+    end
+
+  end
+end; end

--- a/lib/ProMotion/menu/transition.rb
+++ b/lib/ProMotion/menu/transition.rb
@@ -2,42 +2,31 @@ module ProMotion; module Menu
   module Transition
 
      VISUAL_STATES = {
-      slide_and_scale:
-        {
-          block: MMDrawerVisualState.slideAndScaleVisualStateBlock,
-          # "Creates a slide and scale visual state block that gives an experience similar to Mailbox.app. It scales from 90% to 100%, and translates 50 pixels in the x direction. In addition, it also sets alpha from 0.0 to 1.0."
-        },
-      slide:
-        {
-          block: MMDrawerVisualState.slideVisualStateBlock,
-          # "Creates a slide visual state block that gives the user an experience that slides at the same speed of the center view controller during animation. This is equal to calling parallaxVisualStateBlockWithParallaxFactor: with a parallax factor of 1.0."
-        },
-      parallax:
-        {
-          block: MMDrawerVisualState.parallaxVisualStateBlockWithParallaxFactor(3),
-          # "Creates a parallax experience that slides the side drawer view controller at a different rate than the center view controller during animation. For every parallaxFactor of points moved by the center view controller, the side drawer view controller will move 1 point. Passing in 1.0 is the equivalent of a applying a sliding animation, while passing in 'MAX_FLOAT' is the equivalent of having no animation at all."
-        },
-      swinging_door:
-        {
-          block: MMDrawerVisualState.swingingDoorVisualStateBlock,
-          # "Creates a swinging door visual state block that gives the user an experience that animates the drawer in along the hinge."
-        }
+      slide_and_scale: MMDrawerVisualState.slideAndScaleVisualStateBlock,
+      slide: MMDrawerVisualState.slideVisualStateBlock,
+      parallax: MMDrawerVisualState.parallaxVisualStateBlockWithParallaxFactor(3),
+      swinging_door: MMDrawerVisualState.swingingDoorVisualStateBlock
     }
 
-    def transition_animation=(visualBlock)
-      # Parallax requires a parallaxFactor. Set it by passing the visualBlock block in with underscore parallaxFactor attached to the end. i.e. transition_animation = :parallax_6 for parallaxFactor 6.
+    # slide_and_scale: Creates a slide visual state block that gives the user an experience that slides at the same speed of the center view controller during animation. This is equal to calling parallaxVisualStateBlockWithParallaxFactor: with a parallax factor of 1.0. This is similar to the menu in Spotify's app.
+    # parallax: Creates a parallax experience that slides the side drawer view controller at a different rate than the center view controller during animation. For every parallaxFactor of points moved by the center view controller, the side drawer view controller will move 1 point. Passing in 1.0 is the equivalent of a applying a sliding animation, while passing in 'MAX_FLOAT' is the equivalent of having no animation at all.
+        # parallaxFactor is fed in by appending an underscore and the factor to 'parallax', i.e. :parallax_6 for a desired parallax factor of 6
+    # swinging_door: Creates a swinging door visual state block that gives the user an experience that animates the drawer in along the hinge.
+    # slide_and_scale: Creates a slide and scale visual state block that gives an experience similar to Mailbox.app. It scales from 90% to 100%, and translates 50 pixels in the x direction. In addition, it also sets alpha from 0.0 to 1.0.
 
-      self.setDrawerVisualStateBlock(mask_for_transition(visualBlock))
+    def transition_animation=(visual_block)
+      # Parallax requires a parallax_factor. Set it by passing the visual_block block in with underscore parallax_factor attached to the end. i.e. transition_animation = :parallax_6 for parallax_factor 6.
+      self.setDrawerVisualStateBlock(mask_for_transition(visual_block))
     end
 
-    def mask_for_transition(visualBlock)
-      unless visualBlock.nil?
-        if visualBlock.include? "parallax"
-          parallax_factor = visualBlock.include?("_") ? visualBlock.split("_")[1].to_i : 3
+    def mask_for_transition(visual_block)
+      unless visual_block.nil?
+        if visual_block.include? "parallax"
+          parallax_factor = visual_block.include?("_") ? visual_block.split("_")[1].to_i : 3
           visual_state = MMDrawerVisualState.parallaxVisualStateBlockWithParallaxFactor(parallax_factor)
         end
       end
-      visual_state ||= VISUAL_STATES.keys.include?(visualBlock) ? VISUAL_STATES[visualBlock][:block] : nil
+      visual_state ||= VISUAL_STATES.keys.include?(visual_block) ? VISUAL_STATES[visual_block] : nil
       visual_state
     end
 

--- a/lib/ProMotion/menu/transition.rb
+++ b/lib/ProMotion/menu/transition.rb
@@ -26,7 +26,7 @@ module ProMotion; module Menu
           visual_state = MMDrawerVisualState.parallaxVisualStateBlockWithParallaxFactor(parallax_factor)
         end
       end
-      visual_state ||= VISUAL_STATES.keys.include?(visual_block) ? VISUAL_STATES[visual_block] : nil
+      visual_state ||= VISUAL_STATES[visual_block]
       visual_state
     end
 

--- a/spec/transition_spec.rb
+++ b/spec/transition_spec.rb
@@ -1,0 +1,40 @@
+describe ProMotion::Menu::Transition do
+
+  before do
+    @object = Object.new
+    @object.extend(ProMotion::Menu::Transition)
+
+    @delegate = UIApplication.sharedApplication.delegate
+    @left = LeftNavScreen.new
+    @right = RightNavScreen.new
+    @content = BlankScreen.new
+  end
+
+
+  describe "#visualStates" do
+
+    it "returns a visualStateBlock for slideAndScale" do
+      @object.mask_for_transition(:slide_and_scale).is_a?(Proc).should == true
+    end
+
+    it "returns a visualStateBlock for slide" do
+      @object.mask_for_transition(:slide).is_a?(Proc).should == true
+    end
+
+    it "returns a visualStateBlock for swingingDoor" do
+      @object.mask_for_transition(:slide_and_scale).is_a?(Proc).should == true
+    end
+
+    it "returns a visualStateBlock for parallax, when passing in a factor" do
+      @object.mask_for_transition(:parallax_5).is_a?(Proc).should == true
+    end
+
+    it "returns a visualStateBlock for parallax, default factor" do
+      @object.mask_for_transition(:parallax).is_a?(Proc).should == true
+    end
+
+  end
+
+
+
+end

--- a/vendor/Podfile.lock
+++ b/vendor/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - MMDrawerController (0.5.6):
-    - MMDrawerController/Core
-    - MMDrawerController/MMDrawerBarButtonItem
-    - MMDrawerController/MMDrawerVisualStates
-    - MMDrawerController/Subclass
+    - MMDrawerController/Core (= 0.5.6)
+    - MMDrawerController/MMDrawerBarButtonItem (= 0.5.6)
+    - MMDrawerController/MMDrawerVisualStates (= 0.5.6)
+    - MMDrawerController/Subclass (= 0.5.6)
   - MMDrawerController/Core (0.5.6)
   - MMDrawerController/MMDrawerBarButtonItem (0.5.6):
     - MMDrawerController/Core
@@ -18,4 +18,4 @@ DEPENDENCIES:
 SPEC CHECKSUMS:
   MMDrawerController: 4bae84535ca7a5f4cb55a66a001e6035c3571677
 
-COCOAPODS: 0.34.4
+COCOAPODS: 0.35.0

--- a/vendor/Podfile.lock
+++ b/vendor/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
-  - MMDrawerController (0.5.6):
-    - MMDrawerController/Core (= 0.5.6)
-    - MMDrawerController/MMDrawerBarButtonItem (= 0.5.6)
-    - MMDrawerController/MMDrawerVisualStates (= 0.5.6)
-    - MMDrawerController/Subclass (= 0.5.6)
-  - MMDrawerController/Core (0.5.6)
-  - MMDrawerController/MMDrawerBarButtonItem (0.5.6):
+  - MMDrawerController (0.5.7):
+    - MMDrawerController/Core (= 0.5.7)
+    - MMDrawerController/MMDrawerBarButtonItem (= 0.5.7)
+    - MMDrawerController/MMDrawerVisualStates (= 0.5.7)
+    - MMDrawerController/Subclass (= 0.5.7)
+  - MMDrawerController/Core (0.5.7)
+  - MMDrawerController/MMDrawerBarButtonItem (0.5.7):
     - MMDrawerController/Core
-  - MMDrawerController/MMDrawerVisualStates (0.5.6):
+  - MMDrawerController/MMDrawerVisualStates (0.5.7):
     - MMDrawerController/Core
-  - MMDrawerController/Subclass (0.5.6):
+  - MMDrawerController/Subclass (0.5.7):
     - MMDrawerController/Core
 
 DEPENDENCIES:
   - MMDrawerController (~> 0.5)
 
 SPEC CHECKSUMS:
-  MMDrawerController: 4bae84535ca7a5f4cb55a66a001e6035c3571677
+  MMDrawerController: c3ab7a318ddc7e2bcd133139c3161af08c6e1197
 
 COCOAPODS: 0.35.0


### PR DESCRIPTION
I added a new 'Transition' module which allows easy access to MMDrawerController's four prebuilt transition animation blocks. These create very smooth reveals for the menu. ProMotion::Menu::Drawer instances now accept the `transition_animation=` method which accepts one of four arguments (descriptions taken from the MMDrawerController docs:
-  `:slide` - Creates a slide visual state block that gives the user an experience that slides at the same speed of the center view controller during animation.
-  `:slide_and_scale` - Creates a slide and scale visual state block that gives an experience similar to Mailbox.app. It scales from 90% to 100%, and translates 50 pixels in the x direction. In addition, it also sets alpha from 0.0 to 1.0. This is similar to how Spotify's menu transitions.
- `:swinging_door` - Creates a swinging door visual state block that gives the user an experience that animates the drawer in along the hinge.
- `:parallax` - Creates a parallax experience that slides the side drawer view controller at a different rate than the center view controller during animation. For every parallaxFactor of points moved by the center view controller, the side drawer view controller will move 1 point. Passing in 1.0 is the equivalent of a applying a sliding animation, while passing in MAX_FLOAT is the equivalent of having no animation at all.
    - Parallax requires a `parallaxFactor` argument, which I've aliased here to be appended onto the :parallax symbol passed into `transition_animation=`. I.e. For a parallax factor of 5 one would pass `:parallax_5`. When only `:parallax` is passed in, the parallax factor defaults to 3.

Descriptions of the individual visual state animation blocks (same as above) are included in the VISUAL_STATES hash in the Transition module.

Tests, though admittedly they are somewhat weak, are also included. 