### PR TITLE
Fix file dependencies issue while working with 'motion-yapper' gem

### DIFF
--- a/lib/ProMotion-menu.rb
+++ b/lib/ProMotion-menu.rb
@@ -13,6 +13,12 @@ Motion::Project::App.setup do |app|
     app.files.insert(insert_point, file)
   end
 
+  # For compatibility with libraries that set detect_dependencies to false
+  app.files_dependencies({
+    "#{core_lib}/drawer.rb" => [ "#{core_lib}/visibility.rb", "#{core_lib}/gestures.rb" ],
+    "#{core_lib}/delegate.rb" => [ "#{core_lib}/drawer.rb" ],
+  })
+  
   app.pods do
     pod 'MMDrawerController', '~> 0.5'
   end


### PR DESCRIPTION
**Gemfile**
```ruby
source "https://rubygems.org"
gem "rake"
gem "motion-cocoapods"
gem "ProMotion"
gem "ProMotion-menu"
gem 'motion-yapper'
```
Run **rake**, then an exception occurred:
```
uninitialized constant ProMotion::Menu::Drawer::Gestures (NameError)
```
The root cause is ProMotion-menu depends on RM auto file dependency detection, but 'motion-yapper' turn off this feature by setting detect_dependencies to false. motion-yapper did this because old version of motion-support is incompatible with auto file dependency detection.
Learning from ProMotion, this issue can be avoided by specify all file dependencies in Rakefile.
clearsightstudio/ProMotion#555